### PR TITLE
Fix directly mqtt for examples/mqtt-ws-server.rs

### DIFF
--- a/examples/mqtt-ws-server.rs
+++ b/examples/mqtt-ws-server.rs
@@ -122,9 +122,9 @@ async fn main() -> std::io::Result<()> {
                     loop {
                         // we can read incoming bytes stream without consuming it
                         let result = io.with_read_buf(|buf| {
-                            if buf.len() < 4 {
+                            if buf.len() < 8 {
                                 None
-                            } else if &buf[..4] == b"MQTT" {
+                            } else if &buf[4..8] == b"MQTT" {
                                 println!("MQTT protocol is selected");
                                 Some(Protocol::Mqtt)
                             } else if &buf[..4] == b"GET " {


### PR DESCRIPTION
I'm not sure, but it looks like the example is trying to support the direct mqtt protocol. If this is the case, then the marker b"MQTT" is slightly shifted by 4 bytes. Use the console client for verification:

`$ mqttx pub -l mqtts --hostname 127.0.0.1 --port 8883 --mqtt-version 3.1.1 -t topic -m message --content-type text --insecure`